### PR TITLE
🔥 Remove environment from full lambda name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   lambda_dir_name = "${var.name_prefix}-${var.lambda_source_dir_name}"
   lambda_dir = "${var.lambda_code_dir}/${local.lambda_dir_name}"
-  lambda_name_full = "${var.name_prefix}-${var.env}-${var.lambda_name}"
+  lambda_name_full = "${var.name_prefix}-${var.lambda_name}"
 }
 
 data aws_iam_policy_document "lambda_assume_role_policy" {

--- a/vars.tf
+++ b/vars.tf
@@ -1,4 +1,7 @@
-variable "env" {}
+variable "env" {
+  type = string
+  description = "Environment (Typically one of 'test', 'stage' or 'prod')"
+}
 variable "lambda_code_dir" {}
 variable "name_prefix" {}
 variable "lambda_name" {}


### PR DESCRIPTION
Some names get too long (IAM role name in the latest instance), and environment should be implicit based on which account one is signed into, so i suggest removing that part from the names.

Interestingly, this practically used to be the case before #1 , where we for some reason used the source code directory name for most resources (`local.lambda_dir_name`). Very possibly it was the same reason, just not very apparent from the names in the code.