### PR TITLE
🔥 Remove local.lambda_dir_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 locals {
-  lambda_dir_name = "${var.name_prefix}-${var.lambda_source_dir_name}"
-  lambda_dir = "${var.lambda_code_dir}/${local.lambda_dir_name}"
+  lambda_dir = "${var.lambda_code_dir}/${var.lambda_source_dir_name}"
   lambda_name_full = "${var.name_prefix}-${var.env}-${var.lambda_name}"
 }
 
@@ -68,7 +67,7 @@ data "archive_file" "lambda_deploy_package" {
 }
 
 resource "aws_lambda_layer_version" "lambda_layers" {
-  for_each = fileset(var.lambda_code_dir, "${local.lambda_dir_name}-dependencies-*.zip")
+  for_each = fileset(var.lambda_code_dir, "${var.lambda_source_dir_name}-dependencies-*.zip")
   filename = "${var.lambda_code_dir}/${each.value}"
   layer_name = trimsuffix(each.value, ".zip")
   compatible_runtimes = [var.python_version]


### PR DESCRIPTION
We don't need this prefix in our source code folder, it only serves to clutter our workspace.