### PR TITLE
Gå bort fra å forvente lambda dependency layers for hver lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ resource "aws_lambda_function" "lambda" {
   handler                        = "handler.handler"
   timeout                        = var.timeout
   source_code_hash               = data.archive_file.lambda_deploy_package.output_base64sha256
-  layers                         = [for layer in local.lambda_layers : layer.arn]
+  layers                         = [for layer in var.lambda_layers : layer.arn]
   runtime                        = var.runtime
   memory_size                    = var.memory
   reserved_concurrent_executions = var.reserved_concurrent_executions

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,10 @@
 locals {
-  lambda_dir = "${var.lambda_code_dir}/${var.lambda_source_dir_name}"
+  lambda_dir       = "${var.lambda_code_dir}/${var.lambda_source_dir_name}"
   lambda_name_full = "${var.name_prefix}-${var.lambda_name}"
+  lambda_layers    = concat([{ arn : "arn:aws:lambda:eu-west-1:336392948345:layer:AWSSDKPandas-Python39:1" }], var.lambda_layers)
 }
 
-data aws_iam_policy_document "lambda_assume_role_policy" {
+data "aws_iam_policy_document" "lambda_assume_role_policy" {
   statement {
     actions = [
       "sts:AssumeRole"
@@ -31,74 +32,63 @@ data "aws_iam_policy_document" "lambda_exec_role_policy_sans_log_group" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  name = "/aws/lambda/${aws_lambda_function.lambda.function_name}"
+  name              = "/aws/lambda/${aws_lambda_function.lambda.function_name}"
   retention_in_days = 365
 }
 
 resource "aws_iam_role" "lambda_role" {
-  name = "${local.lambda_name_full}-role"
+  name               = "${local.lambda_name_full}-role"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
 }
 
 resource "aws_iam_policy" "no_log_group_lambda_policy" {
-  name = "${local.lambda_name_full}-no-log-group-policy"
+  name   = "${local.lambda_name_full}-no-log-group-policy"
   policy = data.aws_iam_policy_document.lambda_exec_role_policy_sans_log_group.json
 }
 
 resource "aws_iam_role_policy_attachment" "no_log_group_lambda_policy_attachment" {
   policy_arn = aws_iam_policy.no_log_group_lambda_policy.arn
-  role = aws_iam_role.lambda_role.name
+  role       = aws_iam_role.lambda_role.name
 }
 
 resource "aws_iam_policy" "lambda_policy" {
-  name = "${local.lambda_name_full}-policy"
+  name   = "${local.lambda_name_full}-policy"
   policy = var.resource_policy
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   policy_arn = aws_iam_policy.lambda_policy.arn
-  role = aws_iam_role.lambda_role.name
+  role       = aws_iam_role.lambda_role.name
 }
 
 data "archive_file" "lambda_deploy_package" {
   output_path = "${local.lambda_dir}.zip"
-  source_dir = local.lambda_dir
+  source_dir  = local.lambda_dir
   type        = "zip"
 }
 
-resource "aws_lambda_layer_version" "lambda_layers" {
-  for_each = fileset(var.lambda_code_dir, "${var.lambda_source_dir_name}-dependencies-*.zip")
-  filename = "${var.lambda_code_dir}/${each.value}"
-  layer_name = trimsuffix(each.value, ".zip")
-  compatible_runtimes = [var.python_version]
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_lambda_function" "lambda" {
-  depends_on = [aws_lambda_layer_version.lambda_layers]
-  filename      = data.archive_file.lambda_deploy_package.output_path
-  function_name = local.lambda_name_full
-  role          = aws_iam_role.lambda_role.arn
-  handler       = "handler.handler"
-  timeout = var.timeout
-  source_code_hash = data.archive_file.lambda_deploy_package.output_base64sha256
-  layers = [for layer in aws_lambda_layer_version.lambda_layers : layer.arn]
-  runtime = var.runtime
-  memory_size = var.memory
+  filename                       = data.archive_file.lambda_deploy_package.output_path
+  function_name                  = local.lambda_name_full
+  role                           = aws_iam_role.lambda_role.arn
+  handler                        = "handler.handler"
+  timeout                        = var.timeout
+  source_code_hash               = data.archive_file.lambda_deploy_package.output_base64sha256
+  layers                         = [for layer in local.lambda_layers : layer.arn]
+  runtime                        = var.runtime
+  memory_size                    = var.memory
   reserved_concurrent_executions = var.reserved_concurrent_executions
   environment {
     variables = var.environment_variables
   }
   vpc_config {
     security_group_ids = var.security_group_ids
-    subnet_ids = var.subnet_ids
+    subnet_ids         = var.subnet_ids
   }
 }
 
 resource "aws_lambda_permission" "allow_bucket" {
-  count = var.allow_bucket != "" ? 1 : 0
+  count         = var.allow_bucket != "" ? 1 : 0
   statement_id  = "AllowExecutionFromS3${local.lambda_name_full}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.lambda.function_name
@@ -107,9 +97,9 @@ resource "aws_lambda_permission" "allow_bucket" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "log_error_filter" {
-  for_each = "stage" == var.env ? {} : var.log_alarm_filters
+  for_each        = "stage" == var.env ? {} : var.log_alarm_filters
   destination_arn = each.value
-  filter_pattern = each.key
-  log_group_name = aws_cloudwatch_log_group.log_group.name
-  name = "log_error_filter_${local.lambda_name_full}"
+  filter_pattern  = each.key
+  log_group_name  = aws_cloudwatch_log_group.log_group.name
+  name            = "log_error_filter_${local.lambda_name_full}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 locals {
   lambda_dir       = "${var.lambda_code_dir}/${var.lambda_source_dir_name}"
   lambda_name_full = "${var.name_prefix}-${var.lambda_name}"
-  lambda_layers    = concat([{ arn : "arn:aws:lambda:eu-west-1:336392948345:layer:AWSSDKPandas-Python39:1" }], var.lambda_layers)
 }
 
 data "aws_iam_policy_document" "lambda_assume_role_policy" {

--- a/vars.tf
+++ b/vars.tf
@@ -1,12 +1,12 @@
 variable "env" {
-  type = string
+  type        = string
   description = "Environment (Typically one of 'test', 'stage' or 'prod')"
 }
 variable "lambda_code_dir" {}
 variable "name_prefix" {}
 variable "lambda_name" {}
 variable "lambda_source_dir_name" {
-  type = string
+  type        = string
   description = "The name of the folder within lambda_code_dir that contains the source code for the lambda"
 }
 variable "runtime" {
@@ -14,19 +14,19 @@ variable "runtime" {
 }
 variable "resource_policy" {}
 variable "security_group_ids" {
-  type = list
+  type    = list(any)
   default = []
 }
 variable "subnet_ids" {
-  type = list
+  type    = list(any)
   default = []
 }
 variable "environment_variables" {
   default = {}
-  type = map
+  type    = map(any)
 }
 variable "layers" {
-  type = list
+  type    = list(any)
   default = []
 }
 variable "timeout" {
@@ -36,7 +36,7 @@ variable "memory" {
   default = 128
 }
 variable "log_alarm_filters" {
-  type = map
+  type    = map(any)
   default = {}
 }
 variable "reserved_concurrent_executions" {
@@ -46,6 +46,13 @@ variable "allow_bucket" {
   default = ""
 }
 variable "python_version" {
-  type = string
+  type    = string
   default = "python3.8"
+}
+variable "lambda_layers" {
+  description = "A list of lambda layers that this lambda will use"
+  type = list(object({
+    arn = string
+  }))
+  default = []
 }


### PR DESCRIPTION
I stedet for å bygge lambda layers for _hver_ lambda, så kan vi dele layers på tvers av alle lambdaer. For å få dette til må vi sende inn layer som en variabel til modulen, slik at det kan håndteres på et nivå over.