### PR TITLE
✨ Add Optional upsert SQL support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,8 +79,7 @@ data "archive_file" "lambda_deploy_package" {
   }
 
   source {
-    count    = var.upsert_query != "" ? 1 : 0
-    content  = data.local_file.upsert_query[0].content
+    content  = var.upsert_query != "" ? data.local_file.upsert_query[0].content : "" 
     filename = "upsert.sql"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -60,14 +60,22 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   role       = aws_iam_role.lambda_role.name
 }
 
+data "local_file" "lambda_handler" {
+  filename = "${local.lambda_dir}/handler.py"
+}
+
 data "local_file" "upsert_query" {
   filename =  "${var.query_dir}/${var.upsert_query}"
 }
 
 data "archive_file" "lambda_deploy_package" {
   output_path = "${local.lambda_dir}.zip"
-  source_dir  = local.lambda_dir
   type        = "zip"
+
+  source {
+    content = data.local_file.lambda_handler.content
+    filename = "handler.py"
+  }
 
   source {
     content = data.local_file.upsert_query.content

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ data "archive_file" "lambda_deploy_package" {
   type        = "zip"
 
   source {
-    content = data.local_file.upsert_query
+    content = data.local_file.upsert_query.content
     filename = "upsert.sql"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ data "local_file" "upsert_query" {
 }
 
 data "archive_file" "lambda_deploy_package" {
-  output_path = "${local.lambda_dir}.zip"
+  output_path = "${var.lambda_code_dir}/out/${var.lambda_name}.zip"
   type        = "zip"
 
   source {

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,8 @@ data "local_file" "lambda_handler" {
 }
 
 data "local_file" "upsert_query" {
-  filename =  "${var.query_dir}/${var.upsert_query}"
+  count    = var.upsert_query != "" ? 1 : 0
+  filename = "${var.query_dir}/${var.upsert_query}"
 }
 
 data "archive_file" "lambda_deploy_package" {
@@ -73,12 +74,13 @@ data "archive_file" "lambda_deploy_package" {
   type        = "zip"
 
   source {
-    content = data.local_file.lambda_handler.content
+    content  = data.local_file.lambda_handler.content
     filename = "handler.py"
   }
 
   source {
-    content = data.local_file.upsert_query.content
+    count    = var.upsert_query != "" ? 1 : 0
+    content  = data.local_file.upsert_query.content
     filename = "upsert.sql"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ data "archive_file" "lambda_deploy_package" {
 
   source {
     count    = var.upsert_query != "" ? 1 : 0
-    content  = data.local_file.upsert_query.content
+    content  = data.local_file.upsert_query[0].content
     filename = "upsert.sql"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -60,10 +60,19 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   role       = aws_iam_role.lambda_role.name
 }
 
+data "local_file" "upsert_query" {
+  filename =  "${var.query_dir}/${var.upsert_query}"
+}
+
 data "archive_file" "lambda_deploy_package" {
   output_path = "${local.lambda_dir}.zip"
   source_dir  = local.lambda_dir
   type        = "zip"
+
+  source {
+    content = data.local_file.upsert_query
+    filename = "upsert.sql"
+  }
 }
 
 resource "aws_lambda_function" "lambda" {

--- a/vars.tf
+++ b/vars.tf
@@ -12,7 +12,7 @@ variable "lambda_source_dir_name" {
 variable "query_dir" {
   type = string
   description = "The local path of the directory with SQL queries"
-  default = "queries"
+  default = "../../queries"
 }
 variable "upsert_query" {
   type = string

--- a/vars.tf
+++ b/vars.tf
@@ -9,6 +9,16 @@ variable "lambda_source_dir_name" {
   type        = string
   description = "The name of the folder within lambda_code_dir that contains the source code for the lambda"
 }
+variable "query_dir" {
+  type = string
+  description = "The local path of the directory with SQL queries"
+  default = "queries"
+}
+variable "upsert_query" {
+  type = string
+  description = "The path/filename (starting from query_dir) of the upsert sql"
+  default = ""
+}
 variable "runtime" {
   default = "python3.8"
 }


### PR DESCRIPTION
Legger til mulighet for å putte SQL-filer med i deploy package.

Kunne potensielt blitt implementert litt mer generisk og f.eks godtatt en liste med filer etc., men da må vi nok kopiere ting til egen mappe før vi zipper opp, som innebærer nye utfordringer ([kopieringen bør være grei](https://stackoverflow.com/questions/48234045/how-do-you-create-an-archive-file-in-terraform), men for å sikre at det ikke blir værende gamle filer i den mappen, så *tror* jeg vi må bruke `local-exec`, som jeg helst vil unngå...)