### PR TITLE
🐛 Add invoke_from_s3 variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,7 @@ resource "aws_lambda_function" "lambda" {
 }
 
 resource "aws_lambda_permission" "allow_bucket" {
-  count         = var.allow_bucket != "" ? 1 : 0
+  count         = var.invoke_from_s3 ? 1 : 0
   statement_id  = "AllowExecutionFromS3${local.lambda_name_full}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.lambda.function_name

--- a/vars.tf
+++ b/vars.tf
@@ -10,14 +10,14 @@ variable "lambda_source_dir_name" {
   description = "The name of the folder within lambda_code_dir that contains the source code for the lambda"
 }
 variable "query_dir" {
-  type = string
+  type        = string
   description = "The local path of the directory with SQL queries"
-  default = "../../queries"
+  default     = "../../queries"
 }
 variable "upsert_query" {
-  type = string
+  type        = string
   description = "The path/filename (starting from query_dir) of the upsert sql"
-  default = ""
+  default     = ""
 }
 variable "runtime" {
   default = "python3.8"
@@ -51,6 +51,11 @@ variable "log_alarm_filters" {
 }
 variable "reserved_concurrent_executions" {
   default = -1
+}
+variable "invoke_from_s3" {
+  type        = bool
+  default     = false
+  description = "Whether the lambda will be invoked from an S3 bucket notification. Use with allow_bucket."
 }
 variable "allow_bucket" {
   default = ""


### PR DESCRIPTION
Because of an annoyance where this module can not be deployed in the same apply as the bucket it depends on, I propose a boolean value to make deployment less painful.

For context, in use, when attempting to deploy this lambda at the same time as the bucket that will invoke it, the following message was returned:
> The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created.