### PR TITLE
🐛 Add application_name to fix bad refs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,6 @@ resource "aws_iam_policy" "no_log_group_lambda_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "no_log_group_lambda_policy_attachment" {
-  name       = "${local.lambda_name_full}-logging-policy-attachment"
   policy_arn = aws_iam_policy.no_log_group_lambda_policy.arn
   role      = aws_iam_role.lambda_role.name
 }

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_log_group" "log_group" {
   tags              = var.tags
 }
 
-resource "aws_iam_policy" "lambda_logging_role_policy" {
+resource "aws_iam_policy" "no_log_group_lambda_policy" {
   name        = "${local.lambda_name_full}-no-log-group-policy"
   path        = "/"
   description = "Policy for creating log groups and logging to cloudwatch for lambda"
@@ -44,9 +44,9 @@ resource "aws_iam_policy" "lambda_logging_role_policy" {
   tags        = var.tags
 }
 
-resource "aws_iam_policy_attachment" "lambda_logging_role_policy_attachment" {
+resource "aws_iam_policy_attachment" "no_log_group_lambda_policy_attachment" {
   name       = "${local.lambda_name_full}-logging-policy-attachment"
-  policy_arn = aws_iam_policy.lambda_logging_role_policy.arn
+  policy_arn = aws_iam_policy.no_log_group_lambda_policy.arn
   roles      = [aws_iam_role.lambda_role.name]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -44,10 +44,10 @@ resource "aws_iam_policy" "no_log_group_lambda_policy" {
   tags        = var.tags
 }
 
-resource "aws_iam_policy_attachment" "no_log_group_lambda_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "no_log_group_lambda_policy_attachment" {
   name       = "${local.lambda_name_full}-logging-policy-attachment"
   policy_arn = aws_iam_policy.no_log_group_lambda_policy.arn
-  roles      = [aws_iam_role.lambda_role.name]
+  role      = aws_iam_role.lambda_role.name
 }
 
 resource "aws_iam_policy" "lambda_policy" {

--- a/main.tf
+++ b/main.tf
@@ -31,13 +31,13 @@ data "aws_iam_policy_document" "lambda_exec_role_policy_sans_log_group" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  name              = "/aws/lambda/${var.name_prefix}-${var.application_name}-${var.lambda_name}"
+  name              = "/aws/lambda/${var.application_name}-${var.lambda_name}"
   retention_in_days = 90
   tags              = var.tags
 }
 
 resource "aws_iam_policy" "lambda_logging_role_policy" {
-  name        = "${var.name_prefix}-${var.application_name}-${var.lambda_name}-logging-policy"
+  name        = "${var.application_name}-${var.lambda_name}-logging-policy"
   path        = "/"
   description = "Policy for creating log groups and logging to cloudwatch for lambda"
   policy      = data.aws_iam_policy_document.lambda_exec_role_policy_sans_log_group.json
@@ -45,7 +45,7 @@ resource "aws_iam_policy" "lambda_logging_role_policy" {
 }
 
 resource "aws_iam_policy_attachment" "lambda_logging_role_policy_attachment" {
-  name       = "${var.name_prefix}-${var.application_name}-${var.lambda_name}-logging-policy-attachment"
+  name       = "${var.application_name}-${var.lambda_name}-logging-policy-attachment"
   policy_arn = aws_iam_policy.lambda_logging_role_policy.arn
   roles      = [aws_iam_role.lambda_role.name]
 }

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_cloudwatch_log_group" "log_group" {
 }
 
 resource "aws_iam_policy" "lambda_logging_role_policy" {
-  name        = "${local.lambda_name_full}-logging-policy"
+  name        = "${local.lambda_name_full}-no-log-group-policy"
   path        = "/"
   description = "Policy for creating log groups and logging to cloudwatch for lambda"
   policy      = data.aws_iam_policy_document.lambda_exec_role_policy_sans_log_group.json

--- a/main.tf
+++ b/main.tf
@@ -36,17 +36,23 @@ resource "aws_cloudwatch_log_group" "log_group" {
   tags              = var.tags
 }
 
+resource "aws_iam_role" "lambda_role" {
+  name               = "${local.lambda_name_full}-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  tags               = var.tags
+}
+
 resource "aws_iam_policy" "no_log_group_lambda_policy" {
-  name        = "${local.lambda_name_full}-no-log-group-policy"
-  path        = "/"
+  name = "${local.lambda_name_full}-no-log-group-policy"
+  path = "/"
   // description = "Policy for creating log groups and logging to cloudwatch for lambda"
-  policy      = data.aws_iam_policy_document.lambda_exec_role_policy_sans_log_group.json
-  tags        = var.tags
+  policy = data.aws_iam_policy_document.lambda_exec_role_policy_sans_log_group.json
+  tags   = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "no_log_group_lambda_policy_attachment" {
   policy_arn = aws_iam_policy.no_log_group_lambda_policy.arn
-  role      = aws_iam_role.lambda_role.name
+  role       = aws_iam_role.lambda_role.name
 }
 
 resource "aws_iam_policy" "lambda_policy" {
@@ -58,12 +64,6 @@ resource "aws_iam_policy" "lambda_policy" {
 resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   policy_arn = aws_iam_policy.lambda_policy.arn
   role       = aws_iam_role.lambda_role.name
-}
-
-resource "aws_iam_role" "lambda_role" {
-  name               = "${local.lambda_name_full}-role"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-  tags               = var.tags
 }
 
 data "local_file" "lambda_handler" {

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
 }
 
 resource "aws_iam_role" "lambda_role" {
-  name               = "${local.lambda_name_full}-iam"
+  name               = "${local.lambda_name_full}-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
   tags               = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_log_group" "log_group" {
 resource "aws_iam_policy" "no_log_group_lambda_policy" {
   name        = "${local.lambda_name_full}-no-log-group-policy"
   path        = "/"
-  description = "Policy for creating log groups and logging to cloudwatch for lambda"
+  // description = "Policy for creating log groups and logging to cloudwatch for lambda"
   policy      = data.aws_iam_policy_document.lambda_exec_role_policy_sans_log_group.json
   tags        = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   lambda_name_full = "${var.name_prefix}-${var.lambda_name}"
 }
 
-data "aws_iam_policy_document" "lambda_assume_role_policy" {
+data "aws_iam_policy_document" "assume_role" {
   statement {
     actions = [
       "sts:AssumeRole"
@@ -31,26 +31,23 @@ data "aws_iam_policy_document" "lambda_exec_role_policy_sans_log_group" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  name              = "/aws/lambda/${aws_lambda_function.lambda.function_name}"
-  retention_in_days = 365
+  name              = "/aws/lambda/${var.name_prefix}-${var.application_name}-${var.lambda_name}"
+  retention_in_days = 90
   tags              = var.tags
 }
 
-resource "aws_iam_role" "lambda_role" {
-  name               = "${local.lambda_name_full}-role"
-  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
-  tags               = var.tags
+resource "aws_iam_policy" "lambda_logging_role_policy" {
+  name        = "${var.name_prefix}-${var.application_name}-${var.lambda_name}-logging-policy"
+  path        = "/"
+  description = "Policy for creating log groups and logging to cloudwatch for lambda"
+  policy      = data.aws_iam_policy_document.lambda_exec_role_policy_sans_log_group.json
+  tags        = var.tags
 }
 
-resource "aws_iam_policy" "no_log_group_lambda_policy" {
-  name   = "${local.lambda_name_full}-no-log-group-policy"
-  policy = data.aws_iam_policy_document.lambda_exec_role_policy_sans_log_group.json
-  tags   = var.tags
-}
-
-resource "aws_iam_role_policy_attachment" "no_log_group_lambda_policy_attachment" {
-  policy_arn = aws_iam_policy.no_log_group_lambda_policy.arn
-  role       = aws_iam_role.lambda_role.name
+resource "aws_iam_policy_attachment" "lambda_logging_role_policy_attachment" {
+  name       = "${var.name_prefix}-${var.application_name}-${var.lambda_name}-logging-policy-attachment"
+  policy_arn = aws_iam_policy.lambda_logging_role_policy.arn
+  roles      = [aws_iam_role.lambda_role.name]
 }
 
 resource "aws_iam_policy" "lambda_policy" {
@@ -62,6 +59,12 @@ resource "aws_iam_policy" "lambda_policy" {
 resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   policy_arn = aws_iam_policy.lambda_policy.arn
   role       = aws_iam_role.lambda_role.name
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name               = "${var.name_prefix}-${var.application_name}-${var.lambda_name}-iam"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  tags               = var.tags
 }
 
 data "local_file" "lambda_handler" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   lambda_dir       = "${var.lambda_code_dir}/${var.lambda_source_dir_name}"
-  lambda_name_full = "${var.name_prefix}-${var.lambda_name}"
+  lambda_name_full = "${var.application_name}-${var.lambda_name}"
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -31,13 +31,13 @@ data "aws_iam_policy_document" "lambda_exec_role_policy_sans_log_group" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  name              = "/aws/lambda/${var.application_name}-${var.lambda_name}"
+  name              = "/aws/lambda/${local.lambda_name_full}"
   retention_in_days = 90
   tags              = var.tags
 }
 
 resource "aws_iam_policy" "lambda_logging_role_policy" {
-  name        = "${var.application_name}-${var.lambda_name}-logging-policy"
+  name        = "${local.lambda_name_full}-logging-policy"
   path        = "/"
   description = "Policy for creating log groups and logging to cloudwatch for lambda"
   policy      = data.aws_iam_policy_document.lambda_exec_role_policy_sans_log_group.json
@@ -45,7 +45,7 @@ resource "aws_iam_policy" "lambda_logging_role_policy" {
 }
 
 resource "aws_iam_policy_attachment" "lambda_logging_role_policy_attachment" {
-  name       = "${var.application_name}-${var.lambda_name}-logging-policy-attachment"
+  name       = "${local.lambda_name_full}-logging-policy-attachment"
   policy_arn = aws_iam_policy.lambda_logging_role_policy.arn
   roles      = [aws_iam_role.lambda_role.name]
 }
@@ -62,7 +62,7 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
 }
 
 resource "aws_iam_role" "lambda_role" {
-  name               = "${var.application_name}-${var.lambda_name}-iam"
+  name               = "${local.lambda_name_full}-iam"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
   tags               = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
 }
 
 resource "aws_iam_role" "lambda_role" {
-  name               = "${var.name_prefix}-${var.application_name}-${var.lambda_name}-iam"
+  name               = "${var.application_name}-${var.lambda_name}-iam"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
   tags               = var.tags
 }

--- a/vars.tf
+++ b/vars.tf
@@ -76,3 +76,8 @@ variable "tags" {
   description = "Tags applied to all resources in the deployment"
   default     = {}
 }
+variable "application_name" {
+  description = "The name of the application. Used together with name_prefix to name application-specific resources"
+  type        = string
+}
+

--- a/vars.tf
+++ b/vars.tf
@@ -3,7 +3,6 @@ variable "env" {
   description = "Environment (Typically one of 'test', 'stage' or 'prod')"
 }
 variable "lambda_code_dir" {}
-variable "name_prefix" {}
 variable "lambda_name" {}
 variable "lambda_source_dir_name" {
   type        = string

--- a/vars.tf
+++ b/vars.tf
@@ -76,7 +76,7 @@ variable "tags" {
   default     = {}
 }
 variable "application_name" {
-  description = "The name of the application. Used together with name_prefix to name application-specific resources"
+  description = "The name of the application. Used to name application-specific resources, making them easily recognizable"
   type        = string
 }
 


### PR DESCRIPTION
Last config was not actually valid, and caused more changes than desired.

This change adds a missing `application_name`-variable and removes `name_prefix`, as it is less representative of its use.

The change also reduces log retention saves cost (and makes us more data-compliant, i believe)