### PR TITLE
♻️ Simplify lambda name and parameters

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -2,9 +2,16 @@ variable "env" {
   type        = string
   description = "Environment (Typically one of 'test', 'stage' or 'prod')"
 }
-variable "lambda_code_dir" {}
-variable "lambda_name" {}
-variable "lambda_source_dir_name" {
+variable "lambda_dir" {
+  type = string
+  description = "Common dir for lambda code"
+  default = "../../lambda"
+}
+variable "lambda_name" {
+  type = string
+  description = "The full name of the lambda function"
+}
+variable "lambda_subdir" {
   type        = string
   description = "The name of the folder within lambda_code_dir that contains the source code for the lambda"
 }
@@ -21,7 +28,7 @@ variable "upsert_query" {
 variable "runtime" {
   default = "python3.8"
 }
-variable "resource_policy" {}
+variable "resource_policy_json" {}
 variable "security_group_ids" {
   type    = list(any)
   default = []
@@ -33,10 +40,6 @@ variable "subnet_ids" {
 variable "environment_variables" {
   default = {}
   type    = map(any)
-}
-variable "layers" {
-  type    = list(any)
-  default = []
 }
 variable "timeout" {
   default = 120
@@ -51,18 +54,6 @@ variable "log_alarm_filters" {
 variable "reserved_concurrent_executions" {
   default = -1
 }
-variable "invoke_from_s3" {
-  type        = bool
-  default     = false
-  description = "Whether the lambda will be invoked from an S3 bucket notification. Use with allow_bucket."
-}
-variable "allow_bucket" {
-  default = ""
-}
-variable "python_version" {
-  type    = string
-  default = "python3.8"
-}
 variable "lambda_layers" {
   description = "A list of lambda layers that this lambda will use"
   type = list(object({
@@ -70,13 +61,3 @@ variable "lambda_layers" {
   }))
   default = []
 }
-variable "tags" {
-  type        = map(any)
-  description = "Tags applied to all resources in the deployment"
-  default     = {}
-}
-variable "application_name" {
-  description = "The name of the application. Used to name application-specific resources, making them easily recognizable"
-  type        = string
-}
-


### PR DESCRIPTION
In https://github.com/nsbno/cdp-ingestion/pull/64, we learned that it's hard not to pass very many variables when this module wants to create a very specific naming scheme, and that there's a few changes we can do to simplify the use of this module.

This change will:
- Let the user set the full lambda name as a parameter, instead of constructing it from multiple parameters.
- Remove lambda permission for invoking from S3 (⚠️). This is no longer as frequently used, and can easily be done outside of the module, using a single resource.
- Remove tagging, expecting the user to use default tags for their AWS provider in terraform instead.
- Rename parameters for clarity.
- Remove unnecessary parameters.
- Remove unused parameters.