### PR TITLE
🚑🔥 Remove deprecated lambda_permission output.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -7,6 +7,3 @@ output "invoke_arn" {
 output "function_name" {
   value = aws_lambda_function.lambda.function_name
 }
-output "lambda_permission" {
-  value = var.allow_bucket != "" ? aws_lambda_permission.allow_bucket[0].id : ""
-}


### PR DESCRIPTION
PR #11 did not remove the final reference to the bucket invoke lambda permission.

This hotfix removes said output to avoid referencing a non-existent resource declaration.