### PR TITLE
✨ Make resource policy optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "aws_iam_policy" "lambda_policy" {
 
 resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   count = var.resource_policy_json != "" ? 1 : 0
-  policy_arn = aws_iam_policy.lambda_policy.arn
+  policy_arn = aws_iam_policy.lambda_policy[0].arn
   role       = aws_iam_role.lambda_role.name
 }
 

--- a/main.tf
+++ b/main.tf
@@ -48,11 +48,13 @@ resource "aws_iam_role_policy_attachment" "no_log_group_lambda_policy_attachment
 }
 
 resource "aws_iam_policy" "lambda_policy" {
+  count = var.resource_policy_json != "" ? 1 : 0
   name   = "${var.lambda_name}-policy"
   policy = var.resource_policy_json
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
+  count = var.resource_policy_json != "" ? 1 : 0
   policy_arn = aws_iam_policy.lambda_policy.arn
   role       = aws_iam_role.lambda_role.name
 }

--- a/vars.tf
+++ b/vars.tf
@@ -28,7 +28,10 @@ variable "upsert_query" {
 variable "runtime" {
   default = "python3.8"
 }
-variable "resource_policy_json" {}
+variable "resource_policy_json" {
+  type    = string
+  default = ""
+}
 variable "security_group_ids" {
   type    = list(any)
   default = []


### PR DESCRIPTION
Not all lambdas need a resource policy with special privileges.

This change makes the variable optional by only creating the policy and policy attachment if provided